### PR TITLE
Add nvme-connect-nbft.service, and minor fixes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -209,6 +209,7 @@ endforeach
 systemd_files = [
   'nvmefc-boot-connections.service',
   'nvmf-autoconnect.service',
+  'nvmf-connect-nbft.service',
   'nvmf-connect.target',
   'nvmf-connect@.service',
 ]

--- a/meson.build
+++ b/meson.build
@@ -225,6 +225,7 @@ endforeach
 udev_files = [
   '70-nvmf-autoconnect.rules',
   '71-nvmf-iopolicy-netapp.rules',
+  '65-persistent-net-nbft.rules',
 ]
 
 foreach file : udev_files

--- a/nvme.c
+++ b/nvme.c
@@ -9214,7 +9214,7 @@ static int show_nbft_compat_cmd(int argc, char **argv, struct command *command, 
 	for (i = 1; i < argc; i++)
 		argv_plugin[1 + i] = argv[i];
 
-	err = handle_plugin(argc, argv_plugin, plugin);
+	err = handle_plugin(argc + 1, argv_plugin, plugin);
 
 	free(argv_plugin);
 

--- a/nvmf-autoconnect/systemd/nvmf-autoconnect.service.in
+++ b/nvmf-autoconnect/systemd/nvmf-autoconnect.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=Connect NVMe-oF subsystems automatically during boot
-ConditionPathExists=|!@SYSCONFDIR@/nvme/config.json
-ConditionPathExists=|!@SYSCONFDIR@/nvme/discovery.conf
+ConditionPathExists=|@SYSCONFDIR@/nvme/config.json
+ConditionPathExists=|@SYSCONFDIR@/nvme/discovery.conf
 After=network-online.target
 Before=remote-fs-pre.target
 

--- a/nvmf-autoconnect/systemd/nvmf-connect-nbft.service.in
+++ b/nvmf-autoconnect/systemd/nvmf-connect-nbft.service.in
@@ -1,0 +1,11 @@
+# This unit is meant to be started by network management software
+# after a network interface defined in the NBFT gets set up
+[Unit]
+Description=Connect NBFT-defined NVMe-oF subsystems automatically
+ConditionPathExists=|/sys/firmware/acpi/tables/NBFT
+ConditionPathExists=|/sys/firmware/acpi/tables/NBFT1
+
+[Service]
+Type=oneshot
+ExecStartPre=/sbin/modprobe nvme-fabrics
+ExecStart=@SBINDIR@/nvme connect-nbft

--- a/nvmf-autoconnect/udev-rules/65-persistent-net-nbft.rules.in
+++ b/nvmf-autoconnect/udev-rules/65-persistent-net-nbft.rules.in
@@ -1,0 +1,2 @@
+# Avoid renaming nbft$X interfaces
+SUBSYSTEM=="net", ACTION=="add", ENV{INTERFACE}=="nbft*", NAME:="%E{INTERFACE}"

--- a/subprojects/libnvme.wrap
+++ b/subprojects/libnvme.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
-url = https://github.com/linux-nvme/libnvme.git
-revision = a8a5d300c70fc30ffd793bb5726a4ec3d0719163
+url = https://github.com/openSUSE/libnvme.git
+revision = SLE15-SP5-next
 
 [provide]
 libnvme = libnvme_dep


### PR DESCRIPTION
This PR adds a service unit for starting up NBFT-defined NVMe connections after switching root (https://bugzilla.suse.com/show_bug.cgi?id=1211647), and an udev rule that avoids the later renaming of `nbft${X}` interfaces by any interface naming policy that the system may have in place (also bug 1211647).

Also, it adds some small bug fixes, and a convenience patch for local compilation of the SLE15-SP5 branch.


