### PR TITLE
nvmf-autoconnect: add NetworkManager dispatcher script

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,7 @@ sysconfdir = join_paths(prefixdir, get_option('sysconfdir'))
 udevrulesdir   = join_paths(prefixdir, get_option('udevrulesdir'))
 dracutrulesdir = join_paths(prefixdir, get_option('dracutrulesdir'))
 systemddir     = join_paths(prefixdir, get_option('systemddir'))
+nmdispatchdir  = join_paths(prefixdir, get_option('nmdispatchdir'))
 rundir         = join_paths(prefixdir, get_option('rundir'))
 
 ###############################################################################
@@ -277,6 +278,21 @@ foreach file : udev_files
     input: 'nvmf-autoconnect/udev-rules/' + file + '.in',
     output: file,
     configuration: substs,
+  )
+endforeach
+
+nm_dispatcher_files = [
+  '80-nvmf-connect-nbft.sh'
+]
+
+foreach file : nm_dispatcher_files
+  configure_file(
+    input: 'nvmf-autoconnect/nm-dispatcher/' + file + '.in',
+    output: file,
+    configuration: substs,
+    install: true,
+    install_mode: 'rwxr-xr-x',
+    install_dir: nmdispatchdir
   )
 endforeach
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -66,6 +66,12 @@ option(
   description : 'directory for udev rules files'
 )
 option(
+  'nmdispatchdir',
+  type : 'string',
+  value : 'lib/NetworkManager/dispatcher.d',
+  description : 'directory for NetworkManager dispatcher scripts'
+)
+option(
   'version-tag',
   type : 'string',
   description : 'override the git version string'

--- a/nvmf-autoconnect/nm-dispatcher/80-nvmf-connect-nbft.sh.in
+++ b/nvmf-autoconnect/nm-dispatcher/80-nvmf-connect-nbft.sh.in
@@ -1,0 +1,27 @@
+#! /bin/sh
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# If an interface is brought up that is configured in the NVMeoF
+# Boot Firmware Table (NBFT), try to establish possibly missing
+# NVMe connections from the NBFT.
+# This can happen if an interface couldn't be brought up during
+# initramfs processing, but is activated later on.
+
+start_nvmf=
+
+if [ "$2" = up ]; then
+    case $1 in
+	nbft*)
+	    start_nvmf=yes
+	    ;;
+    esac
+    case $CONNECTION_ID in
+        "NBFT connection HFI"*)
+	    start_nvmf=yes
+            ;;
+    esac
+fi
+
+if [ "$start_nvmf" ]; then
+    @SYSTEMCTL@ --no-block start nvmf-connect-nbft.service || true
+fi


### PR DESCRIPTION
If an interface is brought up that is configured in the NVMeoF Boot Firmware Table (NBFT), we need to establish possibly missing NVMe connections from the NBFT. This can happen if an interface couldn't be brought up during initramfs processing, but is activated later on.

Add a NM-dispatcher script that takes care of the connection attempt.